### PR TITLE
Fix auth middleware and login password validation

### DIFF
--- a/src/HospitalController/New User and Old/user.controller.js
+++ b/src/HospitalController/New User and Old/user.controller.js
@@ -101,7 +101,7 @@ const loginUser=asynchandler(async(req,res)=>{
     throw new ApiError(404,"User doesn't exist");
   }
 
-  const isPasswordValid=user.isPasswordCorrect(password)
+  const isPasswordValid = await user.isPasswordCorrect(password)
   if(!isPasswordValid){
     throw new ApiError(401,"invalid credentials");
   }
@@ -137,7 +137,7 @@ const logoutUser=asynchandler(async(req,res)=>{
         httpOnly:true,
         secure:true
     }
-  return res.status(200).clearCookie("accessToken",options).clearCookie("refereshToken",options).json(new ApiResponse(200,{},"User Loged Out Successfully"))
+  return res.status(200).clearCookie("accessToken",options).clearCookie("refreshToken",options).json(new ApiResponse(200,{},"User Loged Out Successfully"))
 })
 
 

--- a/src/middleware/authentication.js
+++ b/src/middleware/authentication.js
@@ -1,11 +1,11 @@
 import jwt from "jsonwebtoken";
-import { user } from "../HospitalModel/User";
+import { User } from "../HospitalModel/user.js";
 import { asynchandler } from "../HospitalUtils/asynchandler.js";
-import { ApiError } from "../utils/Apierror.js";
+import { ApiError } from "../HospitalUtils/ApiError.js";
 
 export const verifyJWT = asynchandler(async (req, res, next) => {
   try {
-    const token = req.cookies?.accesstoken || req.header("Authorization")?.replace("Bearer ", "");
+  const token = req.cookies?.accessToken || req.header("Authorization")?.replace("Bearer ", "");
 
     if (!token) {
       throw new ApiError(401, "Unauthorized request");
@@ -13,7 +13,7 @@ export const verifyJWT = asynchandler(async (req, res, next) => {
 
     const decodedtoken = jwt.verify(token, process.env.ACCESS_TOKEN_SECRET);
 
-    const user = await user.findById(decodedtoken?._id).select("-password" ,"-refreshToken");
+    const user = await User.findById(decodedtoken?._id).select("-password -refreshToken");
 
     if (!user) {
       throw new ApiError(401, "Invalid Access Token");


### PR DESCRIPTION
## Summary
- fix missing await in password check
- fix cookie name in logout
- repair imports and cookie handling in authentication middleware

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683ff868ea508322a89848cd4f82dae9